### PR TITLE
Add convenience methods for use in Ethereum libraries

### DIFF
--- a/uint128_t.cpp
+++ b/uint128_t.cpp
@@ -297,22 +297,20 @@ uint128_t & uint128_t::operator*=(const uint128_t & rhs){
     return *this;
 }
 
-void uint128_t::ConvertToVector(std::vector<uint8_t> & ret, const uint64_t & val) const
-{
-	ret.push_back(static_cast<uint8_t>(val >> 56));
-	ret.push_back(static_cast<uint8_t>(val >> 48));
-	ret.push_back(static_cast<uint8_t>(val >> 40));
-	ret.push_back(static_cast<uint8_t>(val >> 32));
-	ret.push_back(static_cast<uint8_t>(val >> 24));
-	ret.push_back(static_cast<uint8_t>(val >> 16));
-	ret.push_back(static_cast<uint8_t>(val >> 8));
-	ret.push_back(static_cast<uint8_t>(val));
+void uint128_t::ConvertToVector(std::vector<uint8_t> & ret, const uint64_t & val) const {
+    ret.push_back(static_cast<uint8_t>(val >> 56));
+    ret.push_back(static_cast<uint8_t>(val >> 48));
+    ret.push_back(static_cast<uint8_t>(val >> 40));
+    ret.push_back(static_cast<uint8_t>(val >> 32));
+    ret.push_back(static_cast<uint8_t>(val >> 24));
+    ret.push_back(static_cast<uint8_t>(val >> 16));
+    ret.push_back(static_cast<uint8_t>(val >> 8));
+    ret.push_back(static_cast<uint8_t>(val));
 }
 
-void uint128_t::export_bits(std::vector<uint8_t> &ret) const
-{
-	ConvertToVector(ret, const_cast<const uint64_t&>(UPPER));
-	ConvertToVector(ret, const_cast<const uint64_t&>(LOWER));
+void uint128_t::export_bits(std::vector<uint8_t> &ret) const {
+    ConvertToVector(ret, const_cast<const uint64_t&>(UPPER));
+    ConvertToVector(ret, const_cast<const uint64_t&>(LOWER));
 }
 
 std::pair <uint128_t, uint128_t> uint128_t::divmod(const uint128_t & lhs, const uint128_t & rhs) const{

--- a/uint128_t.cpp
+++ b/uint128_t.cpp
@@ -20,6 +20,46 @@ uint128_t::uint128_t(uint128_t && rhs)
     }
 }
 
+uint128_t::uint128_t(const char *s)
+{
+	if (s == NULL || s[0] == 0) { uint128_t(); return; }
+	if (s[1] == 'x')
+		s += 2;
+	else if (*s == 'x')
+		s++;
+
+	UPPER = ConvertToUint64(s);
+	LOWER = ConvertToUint64(s+16);
+}
+
+uint64_t uint128_t::ConvertToUint64(const char *s)
+{
+	int count = 0;
+	uint64_t val = 0;
+	uint8_t hv = HexToInt(s++);
+	while (hv != 0xFF && count < 16)
+	{
+		val = (val << 4) | hv;
+		hv = HexToInt(&s[count]);
+		count++;
+	}
+	return val;
+}
+
+uint8_t uint128_t::HexToInt(const char *s) {
+	uint8_t ret = 0xFF;
+	if (*s >= '0' && *s <= '9') {
+		ret = uint8_t(*s - '0');
+	}
+	else if (*s >= 'a' && *s <= 'f') {
+		ret = uint8_t(*s - 'a' + 10);
+	}
+	else if (*s >= 'A' && *s <= 'F') {
+		ret = uint8_t(*s - 'A' + 10);
+	}
+	return ret;
+}
+
 uint128_t & uint128_t::operator=(const uint128_t & rhs){
     UPPER = rhs.UPPER;
     LOWER = rhs.LOWER;
@@ -254,6 +294,24 @@ uint128_t uint128_t::operator*(const uint128_t & rhs) const{
 uint128_t & uint128_t::operator*=(const uint128_t & rhs){
     *this = *this * rhs;
     return *this;
+}
+
+void uint128_t::ConvertToVector(std::vector<uint8_t> *ret, const uint64_t *val) const
+{
+	ret->push_back(static_cast<uint8_t>(*val >> 56));
+	ret->push_back(static_cast<uint8_t>(*val >> 48));
+	ret->push_back(static_cast<uint8_t>(*val >> 40));
+	ret->push_back(static_cast<uint8_t>(*val >> 32));
+	ret->push_back(static_cast<uint8_t>(*val >> 24));
+	ret->push_back(static_cast<uint8_t>(*val >> 16));
+	ret->push_back(static_cast<uint8_t>(*val >> 8));
+	ret->push_back(static_cast<uint8_t>(*val));
+}
+
+void uint128_t::export_bits(std::vector<uint8_t> *ret) const
+{
+	ConvertToVector(ret, const_cast<const uint64_t*>(&UPPER));
+	ConvertToVector(ret, const_cast<const uint64_t*>(&LOWER));
 }
 
 std::pair <uint128_t, uint128_t> uint128_t::divmod(const uint128_t & lhs, const uint128_t & rhs) const{

--- a/uint128_t.cpp
+++ b/uint128_t.cpp
@@ -20,11 +20,15 @@ uint128_t::uint128_t(uint128_t && rhs)
     }
 }
 
-uint128_t::uint128_t(std::string s) {
-    uint128_t(s.c_str());
+uint128_t::uint128_t(std::string & s) {
+    init(s.c_str());
 }
 
 uint128_t::uint128_t(const char *s) {
+    init(s);
+}
+
+void uint128_t::init(const char *s) {
     if (s == NULL || s[0] == 0) { uint128_t(); return; }
     if (s[1] == 'x')
         s += 2;

--- a/uint128_t.cpp
+++ b/uint128_t.cpp
@@ -20,44 +20,45 @@ uint128_t::uint128_t(uint128_t && rhs)
     }
 }
 
-uint128_t::uint128_t(const char *s)
-{
-	if (s == NULL || s[0] == 0) { uint128_t(); return; }
-	if (s[1] == 'x')
-		s += 2;
-	else if (*s == 'x')
-		s++;
-
-	UPPER = ConvertToUint64(s);
-	LOWER = ConvertToUint64(s+16);
+uint128_t::uint128_t(std::string s) {
+    uint128_t(s.c_str());
 }
 
-uint64_t uint128_t::ConvertToUint64(const char *s)
-{
-	int count = 0;
-	uint64_t val = 0;
-	uint8_t hv = HexToInt(s++);
-	while (hv != 0xFF && count < 16)
-	{
-		val = (val << 4) | hv;
-		hv = HexToInt(&s[count]);
-		count++;
-	}
-	return val;
+uint128_t::uint128_t(const char *s) {
+    if (s == NULL || s[0] == 0) { uint128_t(); return; }
+    if (s[1] == 'x')
+        s += 2;
+    else if (*s == 'x')
+        s++;
+
+    UPPER = ConvertToUint64(s);
+    LOWER = ConvertToUint64(s + 16);
 }
 
-uint8_t uint128_t::HexToInt(const char *s) {
-	uint8_t ret = 0xFF;
-	if (*s >= '0' && *s <= '9') {
-		ret = uint8_t(*s - '0');
-	}
-	else if (*s >= 'a' && *s <= 'f') {
-		ret = uint8_t(*s - 'a' + 10);
-	}
-	else if (*s >= 'A' && *s <= 'F') {
-		ret = uint8_t(*s - 'A' + 10);
-	}
-	return ret;
+uint64_t uint128_t::ConvertToUint64(const char *s) const {
+    int count = 0;
+    uint64_t val = 0;
+    uint8_t hv = HexToInt(s++);
+    while (hv != 0xFF && count < 16) {
+        val = (val << 4) | hv;
+        hv = HexToInt(&s[count]);
+        count++;
+    }
+    return val;
+}
+
+uint8_t uint128_t::HexToInt(const char *s) const {
+    uint8_t ret = 0xFF;
+    if (*s >= '0' && *s <= '9') {
+        ret = uint8_t(*s - '0');
+    }
+    else if (*s >= 'a' && *s <= 'f') {
+        ret = uint8_t(*s - 'a' + 10);
+    }
+    else if (*s >= 'A' && *s <= 'F') {
+        ret = uint8_t(*s - 'A' + 10);
+    }
+    return ret;
 }
 
 uint128_t & uint128_t::operator=(const uint128_t & rhs){
@@ -296,22 +297,22 @@ uint128_t & uint128_t::operator*=(const uint128_t & rhs){
     return *this;
 }
 
-void uint128_t::ConvertToVector(std::vector<uint8_t> *ret, const uint64_t *val) const
+void uint128_t::ConvertToVector(std::vector<uint8_t> & ret, const uint64_t & val) const
 {
-	ret->push_back(static_cast<uint8_t>(*val >> 56));
-	ret->push_back(static_cast<uint8_t>(*val >> 48));
-	ret->push_back(static_cast<uint8_t>(*val >> 40));
-	ret->push_back(static_cast<uint8_t>(*val >> 32));
-	ret->push_back(static_cast<uint8_t>(*val >> 24));
-	ret->push_back(static_cast<uint8_t>(*val >> 16));
-	ret->push_back(static_cast<uint8_t>(*val >> 8));
-	ret->push_back(static_cast<uint8_t>(*val));
+	ret.push_back(static_cast<uint8_t>(val >> 56));
+	ret.push_back(static_cast<uint8_t>(val >> 48));
+	ret.push_back(static_cast<uint8_t>(val >> 40));
+	ret.push_back(static_cast<uint8_t>(val >> 32));
+	ret.push_back(static_cast<uint8_t>(val >> 24));
+	ret.push_back(static_cast<uint8_t>(val >> 16));
+	ret.push_back(static_cast<uint8_t>(val >> 8));
+	ret.push_back(static_cast<uint8_t>(val));
 }
 
-void uint128_t::export_bits(std::vector<uint8_t> *ret) const
+void uint128_t::export_bits(std::vector<uint8_t> &ret) const
 {
-	ConvertToVector(ret, const_cast<const uint64_t*>(&UPPER));
-	ConvertToVector(ret, const_cast<const uint64_t*>(&LOWER));
+	ConvertToVector(ret, const_cast<const uint64_t&>(UPPER));
+	ConvertToVector(ret, const_cast<const uint64_t&>(LOWER));
 }
 
 std::pair <uint128_t, uint128_t> uint128_t::divmod(const uint128_t & lhs, const uint128_t & rhs) const{

--- a/uint128_t.include
+++ b/uint128_t.include
@@ -60,7 +60,8 @@ class uint128_t{
         uint128_t();
         uint128_t(const uint128_t & rhs);
         uint128_t(uint128_t && rhs);
-		uint128_t(const char *val);
+        uint128_t(std::string s);
+        uint128_t(const char *val);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t(const T & rhs)
@@ -95,7 +96,7 @@ class uint128_t{
         // Bitwise Operators
         uint128_t operator&(const uint128_t & rhs) const;
 		
-		void export_bits(std::vector<uint8_t> *ret) const;
+        void export_bits(std::vector<uint8_t> & ret) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator&(const T & rhs) const{
@@ -281,9 +282,9 @@ class uint128_t{
 
     private:
         std::pair <uint128_t, uint128_t> divmod(const uint128_t & lhs, const uint128_t & rhs) const;
-		void ConvertToVector(std::vector<uint8_t> *current, const uint64_t *val) const;
-		uint8_t HexToInt(const char *s);
-		uint64_t ConvertToUint64(const char *s);
+        void ConvertToVector(std::vector<uint8_t> & current, const uint64_t & val) const;
+        uint8_t HexToInt(const char *s) const;
+        uint64_t ConvertToUint64(const char *s) const;
 
     public:
         uint128_t operator/(const uint128_t & rhs) const;

--- a/uint128_t.include
+++ b/uint128_t.include
@@ -40,6 +40,7 @@ to do a general rewrite of this class.
 #include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 class UINT256_T_EXTERN uint128_t;
 
@@ -59,6 +60,7 @@ class uint128_t{
         uint128_t();
         uint128_t(const uint128_t & rhs);
         uint128_t(uint128_t && rhs);
+		uint128_t(const char *val);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t(const T & rhs)
@@ -92,6 +94,8 @@ class uint128_t{
 
         // Bitwise Operators
         uint128_t operator&(const uint128_t & rhs) const;
+		
+		void export_bits(std::vector<uint8_t> *ret) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator&(const T & rhs) const{
@@ -277,6 +281,9 @@ class uint128_t{
 
     private:
         std::pair <uint128_t, uint128_t> divmod(const uint128_t & lhs, const uint128_t & rhs) const;
+		void ConvertToVector(std::vector<uint8_t> *current, const uint64_t *val) const;
+		uint8_t HexToInt(const char *s);
+		uint64_t ConvertToUint64(const char *s);
 
     public:
         uint128_t operator/(const uint128_t & rhs) const;

--- a/uint128_t.include
+++ b/uint128_t.include
@@ -60,8 +60,8 @@ class uint128_t{
         uint128_t();
         uint128_t(const uint128_t & rhs);
         uint128_t(uint128_t && rhs);
-        uint128_t(std::string s);
-        uint128_t(const char *val);
+        uint128_t(std::string & s);
+        uint128_t(const char *s);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t(const T & rhs)
@@ -282,6 +282,7 @@ class uint128_t{
 
     private:
         std::pair <uint128_t, uint128_t> divmod(const uint128_t & lhs, const uint128_t & rhs) const;
+        void init(const char * s);
         void ConvertToVector(std::vector<uint8_t> & current, const uint64_t & val) const;
         uint8_t HexToInt(const char *s) const;
         uint64_t ConvertToUint64(const char *s) const;

--- a/uint256_t.cpp
+++ b/uint256_t.cpp
@@ -26,11 +26,15 @@ uint256_t::uint256_t(uint256_t && rhs)
     }
 }
 
-uint256_t::uint256_t(const std::string s){
-    uint256_t(s.c_str());
+uint256_t::uint256_t(const std::string & s) {
+    init(s.c_str());
 }
 
-uint256_t::uint256_t(const char * s){
+uint256_t::uint256_t(const char * s) {
+    init(s);
+}
+
+void uint256_t::init(const char * s) {
     //create from string
     char buffer[64];
     if (s == NULL) { uint256_t(); return; }
@@ -41,8 +45,7 @@ uint256_t::uint256_t(const char * s){
 
     int len = strlen(s);
     int padLength = 0;
-    if (len < 64)
-    {
+    if (len < 64) {
         padLength = 64 - len;
         memset(buffer, '0', padLength);
     }

--- a/uint256_t.cpp
+++ b/uint256_t.cpp
@@ -1,6 +1,6 @@
 #include "uint256_t.build"
 #include <vector>
-#include <string.h>
+#include <cstring>
 
 const uint128_t uint128_64(64);
 const uint128_t uint128_128(128);
@@ -26,28 +26,31 @@ uint256_t::uint256_t(uint256_t && rhs)
     }
 }
 
-uint256_t::uint256_t(const char * s)
-{
-	//create from string
-	char buffer[64];
-	if (s == NULL) { uint256_t(); return; }
-	if (s[1] == 'x')
-		s += 2;
-	else if (*s == 'x')
-		s++;
+uint256_t::uint256_t(const std::string s){
+    uint256_t(s.c_str());
+}
 
-	int len = strlen(s);
-	int padLength = 0;
-	if (len < 64)
-	{
-		padLength = 64 - len;
-		memset(buffer, '0', padLength);
-	}
+uint256_t::uint256_t(const char * s){
+    //create from string
+    char buffer[64];
+    if (s == NULL) { uint256_t(); return; }
+    if (s[1] == 'x')
+        s += 2;
+    else if (*s == 'x')
+        s++;
 
-	memcpy(buffer + padLength, s, len);
+    int len = strlen(s);
+    int padLength = 0;
+    if (len < 64)
+    {
+        padLength = 64 - len;
+        memset(buffer, '0', padLength);
+    }
 
-	UPPER = uint128_t(buffer);
-	LOWER = uint128_t(buffer + 32);
+    memcpy(buffer + padLength, s, len);
+
+    UPPER = uint128_t(buffer);
+    LOWER = uint128_t(buffer + 32);
 }
 
 uint256_t & uint256_t::operator=(const uint256_t & rhs){
@@ -493,21 +496,16 @@ const uint128_t & uint256_t::lower() const {
     return LOWER;
 }
 
-std::vector<uint8_t> uint256_t::export_bits() const
-{
-	std::vector<uint8_t> ret;
-	ret.reserve(32);
-	UPPER.export_bits(&ret);
-	LOWER.export_bits(&ret);
-	return ret;
+std::vector<uint8_t> uint256_t::export_bits() const {
+    std::vector<uint8_t> ret;
+    ret.reserve(32);
+    UPPER.export_bits(ret);
+    LOWER.export_bits(ret);
+    return ret;
 }
 
-std::vector<uint8_t> uint256_t::export_bits_truncate() const
-{
-	std::vector<uint8_t> ret;
-	ret.reserve(32);
-	UPPER.export_bits(&ret);
-	LOWER.export_bits(&ret);
+std::vector<uint8_t> uint256_t::export_bits_truncate() const {
+    std::vector<uint8_t> ret = export_bits();
 
 	//prune the zeroes
 	int i = 0;

--- a/uint256_t.cpp
+++ b/uint256_t.cpp
@@ -1,4 +1,6 @@
 #include "uint256_t.build"
+#include <vector>
+#include <string.h>
 
 const uint128_t uint128_64(64);
 const uint128_t uint128_128(128);
@@ -22,6 +24,30 @@ uint256_t::uint256_t(uint256_t && rhs)
         rhs.UPPER = uint128_0;
         rhs.LOWER = uint128_0;
     }
+}
+
+uint256_t::uint256_t(const char * s)
+{
+	//create from string
+	char buffer[64];
+	if (s == NULL) { uint256_t(); return; }
+	if (s[1] == 'x')
+		s += 2;
+	else if (*s == 'x')
+		s++;
+
+	int len = strlen(s);
+	int padLength = 0;
+	if (len < 64)
+	{
+		padLength = 64 - len;
+		memset(buffer, '0', padLength);
+	}
+
+	memcpy(buffer + padLength, s, len);
+
+	UPPER = uint128_t(buffer);
+	LOWER = uint128_t(buffer + 32);
 }
 
 uint256_t & uint256_t::operator=(const uint256_t & rhs){
@@ -465,6 +491,30 @@ const uint128_t & uint256_t::upper() const {
 
 const uint128_t & uint256_t::lower() const {
     return LOWER;
+}
+
+std::vector<uint8_t> uint256_t::export_bits() const
+{
+	std::vector<uint8_t> ret;
+	ret.reserve(32);
+	UPPER.export_bits(&ret);
+	LOWER.export_bits(&ret);
+	return ret;
+}
+
+std::vector<uint8_t> uint256_t::export_bits_truncate() const
+{
+	std::vector<uint8_t> ret;
+	ret.reserve(32);
+	UPPER.export_bits(&ret);
+	LOWER.export_bits(&ret);
+
+	//prune the zeroes
+	int i = 0;
+	while (ret[i] == 0 && i < 64) i++;
+	ret.erase(ret.begin(), ret.begin() + i);
+
+	return ret;
 }
 
 uint16_t uint256_t::bits() const{

--- a/uint256_t.include
+++ b/uint256_t.include
@@ -55,6 +55,7 @@ class uint256_t{
         uint256_t();
         uint256_t(const uint256_t & rhs);
         uint256_t(uint256_t && rhs);
+		uint256_t(const char *val);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint256_t(const T & rhs)
@@ -75,6 +76,8 @@ class uint256_t{
         {}
 
         //  RHS input args only
+		std::vector<uint8_t> export_bits() const;
+        std::vector<uint8_t> export_bits_truncate() const;
 
         // Assignment Operator
         uint256_t & operator=(const uint256_t & rhs);

--- a/uint256_t.include
+++ b/uint256_t.include
@@ -55,7 +55,8 @@ class uint256_t{
         uint256_t();
         uint256_t(const uint256_t & rhs);
         uint256_t(uint256_t && rhs);
-		uint256_t(const char *val);
+        uint256_t(const std::string s);
+        uint256_t(const char *val);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint256_t(const T & rhs)

--- a/uint256_t.include
+++ b/uint256_t.include
@@ -55,7 +55,7 @@ class uint256_t{
         uint256_t();
         uint256_t(const uint256_t & rhs);
         uint256_t(uint256_t && rhs);
-        uint256_t(const std::string s);
+        uint256_t(const std::string & s);
         uint256_t(const char *val);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
@@ -312,6 +312,7 @@ class uint256_t{
 
     private:
         std::pair <uint256_t, uint256_t> divmod(const uint256_t & lhs, const uint256_t & rhs) const;
+        void init(const char * s);
 
     public:
         uint256_t operator/(const uint128_t & rhs) const;


### PR DESCRIPTION
- Add constructor to initialise a uint256 from a hex string.
- Add export_bits to uint256 to export fixed length 32 byte vector.
- Add export_bits_truncate to export fitted byte vector.