### PR TITLE
Including fix for MSVC 2019, which ignores is_integral extension

### DIFF
--- a/uint256_t.include
+++ b/uint256_t.include
@@ -72,6 +72,13 @@ class uint256_t{
             : UPPER(upper_rhs), LOWER(lower_rhs)
         {}
 
+        uint256_t(const uint128_t & upper_rhs, const uint128_t & lower_rhs)
+            : UPPER(upper_rhs), LOWER(lower_rhs)
+        {}
+        uint256_t(const uint128_t & lower_rhs)
+            : UPPER(uint128_0), LOWER(lower_rhs)
+        {}
+
        template <typename R, typename S, typename T, typename U,
                 typename = typename std::enable_if<std::is_integral<R>::value &&
                 std::is_integral<S>::value &&


### PR DESCRIPTION
It seems like type-traits in MSVC 2019 are not open for extension, so this includes explicit constructors for uint128_t.

Maybe not the best solution, but it seems backwards compatible from my testing.

MSVC was issuing the following errors:

```
build\release\share\src\uint256_t\uint256_t.cpp(8): error C2661: 'uint256_t::uint256_t': no overloaded function takes 2 arguments
build\release\share\src\uint256_t\uint256_t.cpp(68): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(68): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(72): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(72): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(88): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(88): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(92): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(92): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(107): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(107): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(111): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(111): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(126): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(126): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(130): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(130): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(139): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(139): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(145): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(145): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(148): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(148): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(156): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(156): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(165): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(165): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(174): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(174): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(180): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(180): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(183): error C2440: '<function-style-cast>': cannot convert from 'uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(183): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(191): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(191): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(204): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(204): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(212): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(212): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(220): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(220): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(228): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(228): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(236): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(236): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(250): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(250): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(264): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(264): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(272): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(272): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(280): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(280): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(284): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(284): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(288): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(288): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(298): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(298): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(302): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(302): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(306): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(306): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(315): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(315): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(350): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(350): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(351): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(351): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(352): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(352): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(353): error C2440: '<function-style-cast>': cannot convert from 'uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(353): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(357): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(357): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(399): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(399): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(407): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(407): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(416): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(416): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(424): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(424): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(559): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(559): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(579): error C2440: '<function-style-cast>': cannot convert from 'uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(579): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(604): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(604): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(624): error C2440: '<function-style-cast>': cannot convert from 'uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(624): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(682): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(682): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(686): error C2440: '<function-style-cast>': cannot convert from 'uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(686): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(691): error C2440: '<function-style-cast>': cannot convert from 'const uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(691): note: No constructor could take the source type, or constructor overload resolution was ambiguous
build\release\share\src\uint256_t\uint256_t.cpp(695): error C2440: '<function-style-cast>': cannot convert from 'uint128_t' to 'uint256_t'
build\release\share\src\uint256_t\uint256_t.cpp(695): note: No constructor could take the source type, or constructor overload resolution was ambiguous
```