### PR TITLE
Added support for little endian format

### DIFF
--- a/endianness.h
+++ b/endianness.h
@@ -1,0 +1,24 @@
+#ifndef _ENDIANNESS_H_
+#define _ENDIANNESS_H_
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || \
+    defined(__BIG_ENDIAN__) ||                               \
+    defined(__ARMEB__) ||                                    \
+    defined(__THUMBEB__) ||                                  \
+    defined(__AARCH64EB__) ||                                \
+    defined(_MIBSEB) || defined(__MIBSEB) || defined(__MIBSEB__)
+#ifndef __BIG_ENDIAN__
+#define __BIG_ENDIAN__
+#endif
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+    defined(__LITTLE_ENDIAN__) ||                                 \
+    defined(__ARMEL__) ||                                         \
+    defined(__THUMBEL__) ||                                       \
+    defined(__AARCH64EL__) ||                                     \
+    defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__)
+#ifndef __LITTLE_ENDIAN__
+#define __LITTLE_ENDIAN__
+#endif
+#else
+#error "I don't know what architecture this is!"
+#endif
+#endif

--- a/uint128_t.cpp
+++ b/uint128_t.cpp
@@ -4,15 +4,30 @@ const uint128_t uint128_0(0);
 const uint128_t uint128_1(1);
 
 uint128_t::uint128_t()
+#ifdef __BIG_ENDIAN__
     : UPPER(0), LOWER(0)
+#endif
+#ifdef __LITTLE_ENDIAN__
+    : LOWER(0), UPPER(0)
+#endif
 {}
 
 uint128_t::uint128_t(const uint128_t & rhs)
+#ifdef __BIG_ENDIAN__
     : UPPER(rhs.UPPER), LOWER(rhs.LOWER)
+#endif
+#ifdef __LITTLE_ENDIAN__
+    : LOWER(rhs.LOWER), UPPER(rhs.UPPER)
+#endif
 {}
 
 uint128_t::uint128_t(uint128_t && rhs)
+#ifdef __BIG_ENDIAN__
     : UPPER(std::move(rhs.UPPER)), LOWER(std::move(rhs.LOWER))
+#endif
+#ifdef __LITTLE_ENDIAN__
+    : LOWER(std::move(rhs.LOWER)), UPPER(std::move(rhs.UPPER))
+#endif
 {
     if (this != &rhs){
         rhs.UPPER = 0;

--- a/uint128_t.include
+++ b/uint128_t.include
@@ -24,10 +24,10 @@ THE SOFTWARE.
 
 With much help from Auston Sterling
 
-Thanks to Stefan Deigmüller for finding
+Thanks to Stefan DeigmÃ¼ller for finding
 a bug in operator*.
 
-Thanks to François Dessenne for convincing me
+Thanks to FranÃ§ois Dessenne for convincing me
 to do a general rewrite of this class.
 */
 
@@ -42,6 +42,8 @@ to do a general rewrite of this class.
 #include <utility>
 #include <vector>
 
+#include "endianness.h"
+
 class UINT256_T_EXTERN uint128_t;
 
 // Give uint128_t type traits
@@ -53,7 +55,12 @@ namespace std {  // This is probably not a good idea
 
 class uint128_t{
     private:
+#ifdef __BIG_ENDIAN__
         uint64_t UPPER, LOWER;
+#endif
+#ifdef __LITTLE_ENDIAN__
+        uint64_t LOWER, UPPER;
+#endif
 
     public:
         // Constructors
@@ -65,7 +72,12 @@ class uint128_t{
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t(const T & rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(0), LOWER(rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(rhs), UPPER(0)
+#endif
         {
             if (std::is_signed<T>::value) {
                 if (rhs < 0) {
@@ -76,7 +88,12 @@ class uint128_t{
 
         template <typename S, typename T, typename = typename std::enable_if <std::is_integral<S>::value && std::is_integral<T>::value, void>::type>
         uint128_t(const S & upper_rhs, const T & lower_rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(upper_rhs), LOWER(lower_rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(lower_rhs), UPPER(upper_rhs)
+#endif
         {}
 
         //  RHS input args only

--- a/uint256_t.cpp
+++ b/uint256_t.cpp
@@ -10,15 +10,30 @@ const uint256_t uint256_1(1);
 const uint256_t uint256_max(uint128_t((uint64_t) -1, (uint64_t) -1), uint128_t((uint64_t) -1, (uint64_t) -1));
 
 uint256_t::uint256_t()
+#ifdef __BIG_ENDIAN__
     : UPPER(uint128_0), LOWER(uint128_0)
+#endif
+#ifdef __LITTLE_ENDIAN__
+    : LOWER(uint128_0), UPPER(uint128_0)
+#endif
 {}
 
 uint256_t::uint256_t(const uint256_t & rhs)
+#ifdef __BIG_ENDIAN__
     : UPPER(rhs.UPPER), LOWER(rhs.LOWER)
+#endif
+#ifdef __LITTLE_ENDIAN__
+    : LOWER(rhs.LOWER), UPPER(rhs.UPPER)
+#endif
 {}
 
 uint256_t::uint256_t(uint256_t && rhs)
+#ifdef __BIG_ENDIAN__
     : UPPER(std::move(rhs.UPPER)), LOWER(std::move(rhs.LOWER))
+#endif
+#ifdef __LITTLE_ENDIAN__
+    : LOWER(std::move(rhs.LOWER)), UPPER(std::move(rhs.UPPER))
+#endif
 {
     if (this != &rhs){
         rhs.UPPER = uint128_0;

--- a/uint256_t.include
+++ b/uint256_t.include
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 With much help from Auston Sterling
 
-Thanks to François Dessenne for convincing me
+Thanks to FranÃ§ois Dessenne for convincing me
 to do a general rewrite of this class.
 */
 
@@ -48,7 +48,12 @@ namespace std {  // This is probably not a good idea
 
 class uint256_t{
     private:
+#ifdef __BIG_ENDIAN__
         uint128_t UPPER, LOWER;
+#endif
+#ifdef __LITTLE_ENDIAN__
+        uint128_t LOWER, UPPER;
+#endif
 
     public:
         // Constructors
@@ -60,7 +65,12 @@ class uint256_t{
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint256_t(const T & rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(uint128_0), LOWER(rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(rhs), UPPER(uint128_0)
+#endif
         {
             if (rhs < 0) {
                 UPPER = -1;
@@ -69,14 +79,29 @@ class uint256_t{
 
         template <typename S, typename T, typename = typename std::enable_if <std::is_integral<S>::value && std::is_integral<T>::value, void>::type>
         uint256_t(const S & upper_rhs, const T & lower_rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(upper_rhs), LOWER(lower_rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(lower_rhs), UPPER(upper_rhs)
+#endif
         {}
 
         uint256_t(const uint128_t & upper_rhs, const uint128_t & lower_rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(upper_rhs), LOWER(lower_rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(lower_rhs), UPPER(upper_rhs)
+#endif
         {}
         uint256_t(const uint128_t & lower_rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(uint128_0), LOWER(lower_rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(lower_rhs), UPPER(uint128_0)
+#endif
         {}
 
        template <typename R, typename S, typename T, typename U,
@@ -85,7 +110,12 @@ class uint256_t{
                 std::is_integral<T>::value &&
                 std::is_integral<U>::value, void>::type>
         uint256_t(const R & upper_lhs, const S & lower_lhs, const T & upper_rhs, const U & lower_rhs)
+#ifdef __BIG_ENDIAN__
             : UPPER(upper_lhs, lower_lhs), LOWER(upper_rhs, lower_rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(upper_rhs, lower_rhs), UPPER(upper_lhs, lower_lhs)
+#endif
         {}
 
         //  RHS input args only


### PR DESCRIPTION
Added support for *little endian* and *big endian* format of storing numbers.

This change allows the use of `dynamic_cast` to  cast underlying data directly to `uint256_t` and `uint128_t` types.

**Use case:** `byte` array can be casted to `uint128_t` array. This can be useful for implementation of some crypto algorithms.