### PR TITLE
Made uint256_t and uint128_t types trivially copyable

### DIFF
--- a/tests/testcases/constructor.cpp
+++ b/tests/testcases/constructor.cpp
@@ -9,7 +9,7 @@ TEST(Constructor, standard){
     EXPECT_EQ(uint256_t(), 0);
     EXPECT_EQ(value, original);
     EXPECT_EQ(uint256_t(std::move(value)), original);
-    EXPECT_EQ(value, 0);
+    EXPECT_EQ(value, 0x0123456789abcdefULL);
 }
 
 TEST(Constructor, one){

--- a/uint128_t.cpp
+++ b/uint128_t.cpp
@@ -3,38 +3,6 @@
 const uint128_t uint128_0(0);
 const uint128_t uint128_1(1);
 
-uint128_t::uint128_t()
-#ifdef __BIG_ENDIAN__
-    : UPPER(0), LOWER(0)
-#endif
-#ifdef __LITTLE_ENDIAN__
-    : LOWER(0), UPPER(0)
-#endif
-{}
-
-uint128_t::uint128_t(const uint128_t & rhs)
-#ifdef __BIG_ENDIAN__
-    : UPPER(rhs.UPPER), LOWER(rhs.LOWER)
-#endif
-#ifdef __LITTLE_ENDIAN__
-    : LOWER(rhs.LOWER), UPPER(rhs.UPPER)
-#endif
-{}
-
-uint128_t::uint128_t(uint128_t && rhs)
-#ifdef __BIG_ENDIAN__
-    : UPPER(std::move(rhs.UPPER)), LOWER(std::move(rhs.LOWER))
-#endif
-#ifdef __LITTLE_ENDIAN__
-    : LOWER(std::move(rhs.LOWER)), UPPER(std::move(rhs.UPPER))
-#endif
-{
-    if (this != &rhs){
-        rhs.UPPER = 0;
-        rhs.LOWER = 0;
-    }
-}
-
 uint128_t::uint128_t(std::string & s) {
     init(s.c_str());
 }
@@ -78,22 +46,6 @@ uint8_t uint128_t::HexToInt(const char *s) const {
         ret = uint8_t(*s - 'A' + 10);
     }
     return ret;
-}
-
-uint128_t & uint128_t::operator=(const uint128_t & rhs){
-    UPPER = rhs.UPPER;
-    LOWER = rhs.LOWER;
-    return *this;
-}
-
-uint128_t & uint128_t::operator=(uint128_t && rhs){
-    if (this != &rhs){
-        UPPER = std::move(rhs.UPPER);
-        LOWER = std::move(rhs.LOWER);
-        rhs.UPPER = 0;
-        rhs.LOWER = 0;
-    }
-    return *this;
 }
 
 uint128_t::operator bool() const{

--- a/uint128_t.include
+++ b/uint128_t.include
@@ -64,9 +64,9 @@ class uint128_t{
 
     public:
         // Constructors
-        uint128_t();
-        uint128_t(const uint128_t & rhs);
-        uint128_t(uint128_t && rhs);
+        uint128_t() = default;
+        uint128_t(const uint128_t & rhs) = default;
+        uint128_t(uint128_t && rhs) = default;
         uint128_t(std::string & s);
         uint128_t(const char *s);
 
@@ -99,8 +99,8 @@ class uint128_t{
         //  RHS input args only
 
         // Assignment Operator
-        uint128_t & operator=(const uint128_t & rhs);
-        uint128_t & operator=(uint128_t && rhs);
+        uint128_t & operator=(const uint128_t & rhs) = default;
+        uint128_t & operator=(uint128_t && rhs) = default;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t & operator=(const T & rhs){

--- a/uint256_t.cpp
+++ b/uint256_t.cpp
@@ -9,38 +9,6 @@ const uint256_t uint256_0(0);
 const uint256_t uint256_1(1);
 const uint256_t uint256_max(uint128_t((uint64_t) -1, (uint64_t) -1), uint128_t((uint64_t) -1, (uint64_t) -1));
 
-uint256_t::uint256_t()
-#ifdef __BIG_ENDIAN__
-    : UPPER(uint128_0), LOWER(uint128_0)
-#endif
-#ifdef __LITTLE_ENDIAN__
-    : LOWER(uint128_0), UPPER(uint128_0)
-#endif
-{}
-
-uint256_t::uint256_t(const uint256_t & rhs)
-#ifdef __BIG_ENDIAN__
-    : UPPER(rhs.UPPER), LOWER(rhs.LOWER)
-#endif
-#ifdef __LITTLE_ENDIAN__
-    : LOWER(rhs.LOWER), UPPER(rhs.UPPER)
-#endif
-{}
-
-uint256_t::uint256_t(uint256_t && rhs)
-#ifdef __BIG_ENDIAN__
-    : UPPER(std::move(rhs.UPPER)), LOWER(std::move(rhs.LOWER))
-#endif
-#ifdef __LITTLE_ENDIAN__
-    : LOWER(std::move(rhs.LOWER)), UPPER(std::move(rhs.UPPER))
-#endif
-{
-    if (this != &rhs){
-        rhs.UPPER = uint128_0;
-        rhs.LOWER = uint128_0;
-    }
-}
-
 uint256_t::uint256_t(const std::string & s) {
     init(s.c_str());
 }
@@ -69,22 +37,6 @@ void uint256_t::init(const char * s) {
 
     UPPER = uint128_t(buffer);
     LOWER = uint128_t(buffer + 32);
-}
-
-uint256_t & uint256_t::operator=(const uint256_t & rhs){
-    UPPER = rhs.UPPER;
-    LOWER = rhs.LOWER;
-    return *this;
-}
-
-uint256_t & uint256_t::operator=(uint256_t && rhs){
-    if (this != &rhs){
-        UPPER = std::move(rhs.UPPER);
-        LOWER = std::move(rhs.LOWER);
-        rhs.UPPER = uint128_0;
-        rhs.LOWER = uint128_0;
-    }
-    return *this;
 }
 
 uint256_t::operator bool() const{

--- a/uint256_t.include
+++ b/uint256_t.include
@@ -57,9 +57,9 @@ class uint256_t{
 
     public:
         // Constructors
-        uint256_t();
-        uint256_t(const uint256_t & rhs);
-        uint256_t(uint256_t && rhs);
+        uint256_t() = default;
+        uint256_t(const uint256_t & rhs) = default;
+        uint256_t(uint256_t && rhs) = default;
         uint256_t(const std::string & s);
         uint256_t(const char *val);
 
@@ -123,8 +123,8 @@ class uint256_t{
         std::vector<uint8_t> export_bits_truncate() const;
 
         // Assignment Operator
-        uint256_t & operator=(const uint256_t & rhs);
-        uint256_t & operator=(uint256_t && rhs);
+        uint256_t & operator=(const uint256_t & rhs) = default;
+        uint256_t & operator=(uint256_t && rhs) = default;
 
         template <typename T, typename = typename std::enable_if <std::is_integral<T>::value, T>::type>
         uint256_t & operator=(const T & rhs){


### PR DESCRIPTION
This PR makes `uint256_t` and `uint128_t` types trivially copyable.
See: https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable.

Custom copy and move constructor, and copy and move operators are changed with default ones.