### PR TITLE
Fix for stack-buffer-overflow bug in `uint128_t::ConvertToUint64` function

### DIFF
--- a/tests/testcases/constructor.cpp
+++ b/tests/testcases/constructor.cpp
@@ -12,6 +12,14 @@ TEST(Constructor, standard){
     EXPECT_EQ(value, 0x0123456789abcdefULL);
 }
 
+TEST(Constructor, string){
+    EXPECT_EQ(uint256_t("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), uint256_max);
+    EXPECT_EQ(uint256_t("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), uint256_max);
+    EXPECT_EQ(uint256_t("0"), 0);
+    EXPECT_EQ(uint256_t("0"), 0);
+    EXPECT_EQ(uint256_t("0x0123456789abcdef"), 0x0123456789abcdefULL);
+}
+
 TEST(Constructor, one){
     EXPECT_EQ(uint256_t(true).upper(),  false);
     EXPECT_EQ(uint256_t(true).lower(),   true);

--- a/tests/testcases/constructor.cpp
+++ b/tests/testcases/constructor.cpp
@@ -15,7 +15,7 @@ TEST(Constructor, standard){
 TEST(Constructor, string){
     EXPECT_EQ(uint256_t("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), uint256_max);
     EXPECT_EQ(uint256_t("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), uint256_max);
-    EXPECT_EQ(uint256_t("0"), 0);
+    EXPECT_EQ(uint256_t("0x0"), 0);
     EXPECT_EQ(uint256_t("0"), 0);
     EXPECT_EQ(uint256_t("0x0123456789abcdef"), 0x0123456789abcdefULL);
 }

--- a/uint128_t.cpp
+++ b/uint128_t.cpp
@@ -25,11 +25,12 @@ void uint128_t::init(const char *s) {
 uint64_t uint128_t::ConvertToUint64(const char *s) const {
     int count = 0;
     uint64_t val = 0;
-    uint8_t hv = HexToInt(s++);
-    while (hv != 0xFF && count < 16) {
+    while (count < 16) {
+        uint8_t hv = HexToInt(&s[count++]);
+        if (hv == 0xFF)
+            break;
+
         val = (val << 4) | hv;
-        hv = HexToInt(&s[count]);
-        count++;
     }
     return val;
 }


### PR DESCRIPTION
There is stack-buffer-overflow bug in `uint128_t::ConvertToUint64` function.
This bug was caught by clang AddressSanitizier.

The issue is that `s[count]` is outside of buffer last time it is checked.
This PR changes this behavior so stack-buffer-overflow  does not happen.
- Test is added to verify that functionality has staid the same. 