### PR TITLE
changed modulo to use divmod directly to optimize

### DIFF
--- a/uint256_t.cpp
+++ b/uint256_t.cpp
@@ -423,7 +423,7 @@ uint256_t uint256_t::operator%(const uint128_t & rhs) const{
 }
 
 uint256_t uint256_t::operator%(const uint256_t & rhs) const{
-    return *this - (rhs * (*this / rhs));
+    return divmod(*this, rhs).second;
 }
 
 uint256_t & uint256_t::operator%=(const uint128_t & rhs){


### PR DESCRIPTION
the remainder operator uses division to then multiply and subtract.
but we can use the remainder that the divmod gave to the division.